### PR TITLE
Add service account, external ip, firewall rules and new variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,8 @@ locals {
   load_balancer_port_name = var.load_balancer_port != null ? "load-balancer-port" : null
 
   # Construct the script to set environment variables
-  env_script = join("\n", [for k, v in var.env_variables : "echo \"export ${k}='${v}'\" >> /etc/profile\n\nexport ${k}='${v}'"])
-  service_account_env = "echo \"export SERVICE_ACCOUNT='${google_service_account.mig_sa.email}'\" >> /etc/profile\n\nexport SERVICE_ACCOUNT='${google_service_account.mig_sa.email}'"
+  env_script = join("\n", [for k, v in var.env_variables : "echo \"export ${k}='${v}'\" >> /etc/profile\n\necho \"${k}=${v}\" >> /tmp/docker-env.txt"])
+  service_account_env = "echo \"export SERVICE_ACCOUNT='${google_service_account.mig_sa.email}'\" >> /etc/profile\n\necho \"SERVICE_ACCOUNT=${google_service_account.mig_sa.email}\" >> /tmp/docker-env.txt"
 
   # Combine the environment variables script with the user's script
   combined_startup_script = "${local.service_account_env}\n\n${local.env_script}\n\n${var.startup_script}"
@@ -31,6 +31,8 @@ locals {
   run_roles = [
     "roles/cloudsql.instanceUser",
     "roles/cloudsql.client",
+    "roles/storage.objectViewer",
+    "roles/artifactregistry.reader",
   ]
 }
 

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -63,3 +63,12 @@ spec:
         health_check_request_path:
           name: health_check_request_path
           title: Health Check Request Path
+        dependencies:
+          name: dependencies
+          title: Dependencies
+        vm_image_project:
+          name: vm_image_project
+          title: Vm image project
+        public_access_firewall_rule_name:
+          name: public_access_firewall_rule_name
+          title: Firewall rule name for public access

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -82,10 +82,6 @@ spec:
       varType: string
       required: true
       userInputVariable: true
-    - name: service_account_email
-      description: Email of the service account that should be attached to the GCE VMs
-      varType: string
-      userInputVariable: true
     - name: startup_script
       description: Startup script for GCE VMs
       varType: string
@@ -111,6 +107,25 @@ spec:
       varType: string
       defaultValue: "/"
       userInputVariable: true
+    - name: dependencies
+      description: Dependencies for the managed instance group
+      varType: list(any)
+      defaultValue: []
+      userInputVariable: false
+      connections:
+      - compositionUnitID: terraform-google-solution-builder-cloud-sql
+        type: list_merge
+        output: module_dependency
+    - name: vm_image_project
+      description: Project ID where VM image is present
+      varType: string
+      defaultValue: ""
+      userInputVariable: true
+    - name: public_access_firewall_rule_name
+      description: Name for the firewall rule to allow public access
+      varType: string
+      defaultValue: null
+      userInputVariable: true
     outputs:
     - name: load_balancer_port_name
       description: Port name for load balancer to connect to the VM instances
@@ -126,6 +141,9 @@ spec:
       solutionOutputVariable: false
     - name: health_check_link
       description: Health check link
+      solutionOutputVariable: false
+    - name: mig_service_account_name
+      description: Name for service account created for the MIG VMs. This can be used in other module for giving permission.
       solutionOutputVariable: false
   requirements:
     roles:

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "managed_instance_group_url" {
 }
 
 output "health_check_link" {
-  value = var.health_check_name != "" ? module.mig.health_check_self_links[0] : ""
+  value = var.health_check_name != "" ? module.mig.health_check_self_links[0] : null
   description = "Health check link"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "managed_instance_group_url" {
 }
 
 output "health_check_link" {
-  value = var.health_check_name != "" ? module.mig.health_check_self_links[0] : null
+  value = var.health_check_name != "" ? module.mig.health_check_self_links[0] : ""
   description = "Health check link"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,3 +34,7 @@ output "module_dependency" {
   depends_on = [module.instance_template, module.mig]
   description = "Dependency variable that can be used by other modules to depend on this module"
 }
+
+output "mig_service_account_name" {
+  value = "${google_service_account.mig_sa.account_id}@${var.project_id}.iam"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -80,7 +80,7 @@ variable "health_check_request_path" {
 variable "dependencies" {
   type = list(any)
   default = []
-  description = "Dependencies of the manages instance group"
+  description = "Dependencies for the managed instance group"
 }
 
 variable "vm_image_project" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,12 +41,6 @@ variable "network_name" {
   description = "VPC network name where the GCE VMs are created"
 }
 
-variable "service_account_email" {
-  type = string
-  default = null
-  description = "Email of the service account that should be attached to the GCE VMs"
-}
-
 variable "env_variables" {
   type = map(string)
   default = {}
@@ -81,4 +75,22 @@ variable "health_check_request_path" {
   type = string
   default = "/"
   description = "Path where the health check request is sent"
+}
+
+variable "dependencies" {
+  type = list(any)
+  default = []
+  description = "Dependencies of the manages instance group"
+}
+
+variable "vm_image_project" {
+  description = "VM image project id"
+  default = ""
+  type = string
+}
+
+variable "public_access_firewall_rule_name" {
+  type = string
+  default = null
+  description = "Name of the firewall rule to allow public access"
 }


### PR DESCRIPTION
This pull request makes below changes,

* Adds a service account for instance template
* Adds firewall rule for providing public http access
* Adds access_config to provide external ip for instance template
* Update startup script to export env variable so that any program running as part of startup_script would be able to reference env variables.
* Adds new variables and output etc